### PR TITLE
egl: override eglCreatePlatformWindowSurface

### DIFF
--- a/hybris/egl/egl.c
+++ b/hybris/egl/egl.c
@@ -512,6 +512,7 @@ static struct FuncNamePair _eglHybrisOverrideFunctions[] = {
 	OVERRIDE_SAMENAME(eglGetDisplay),
 	OVERRIDE_SAMENAME(eglGetPlatformDisplay),
 	OVERRIDE_SAMENAME(eglTerminate),
+	OVERRIDE_SAMENAME(eglCreatePlatformWindowSurface),
 	OVERRIDE_SAMENAME(eglCreateWindowSurface),
 	OVERRIDE_SAMENAME(eglDestroySurface),
 	OVERRIDE_SAMENAME(eglSwapInterval),


### PR DESCRIPTION
Likely a part of 3df06627441d11559d45aea08cc9e7d8d72c1f1a that got lost during rebase. Needed to fix Qt apps on Manjaro on Android 10 devices.